### PR TITLE
Improve deepobject unmarshalling to support nullable.Nullable and encode.TextUnmarshaler

### DIFF
--- a/deepobject.go
+++ b/deepobject.go
@@ -1,6 +1,7 @@
 package runtime
 
 import (
+	"encoding"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -198,6 +199,18 @@ func assignPathValues(dst interface{}, pathValues fieldOrValue) error {
 
 	iv := reflect.Indirect(v)
 	it := iv.Type()
+
+	switch dst := v.Interface().(type) {
+	case Binder:
+		return dst.Bind(pathValues.value)
+	case encoding.TextUnmarshaler:
+		err := dst.UnmarshalText([]byte(pathValues.value))
+		if err != nil {
+			return fmt.Errorf("error unmarshalling text '%s': %w", pathValues.value, err)
+		}
+
+		return nil
+	}
 
 	switch it.Kind() {
 	case reflect.Map:

--- a/deepobject_test.go
+++ b/deepobject_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/oapi-codegen/runtime/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -17,6 +18,7 @@ type InnerObject struct {
 
 // These are all possible field types, mandatory and optional.
 type AllFields struct {
+	// Primitive types
 	I   int             `json:"i"`
 	Oi  *int            `json:"oi,omitempty"`
 	F   float32         `json:"f"`
@@ -27,10 +29,16 @@ type AllFields struct {
 	Oas *[]string       `json:"oas,omitempty"`
 	O   InnerObject     `json:"o"`
 	Oo  *InnerObject    `json:"oo,omitempty"`
-	D   MockBinder      `json:"d"`
-	Od  *MockBinder     `json:"od,omitempty"`
 	M   map[string]int  `json:"m"`
 	Om  *map[string]int `json:"om,omitempty"`
+
+	// Complex types
+	Bi  MockBinder  `json:"bi"`
+	Obi *MockBinder `json:"obi,omitempty"`
+	Da  types.Date  `json:"da"`
+	Oda *types.Date `json:"oda,omitempty"`
+	Ti  time.Time   `json:"ti"`
+	Oti *time.Time  `json:"oti,omitempty"`
 }
 
 func TestDeepObject(t *testing.T) {
@@ -45,9 +53,13 @@ func TestDeepObject(t *testing.T) {
 	om := map[string]int{
 		"additional": 1,
 	}
-	d := MockBinder{Time: time.Date(2020, 2, 1, 0, 0, 0, 0, time.UTC)}
+
+	bi := MockBinder{Time: time.Date(2020, 2, 1, 0, 0, 0, 0, time.UTC)}
+	da := types.Date{Time: time.Date(2020, 2, 2, 0, 0, 0, 0, time.UTC)}
+	ti := time.Now().UTC()
 
 	srcObj := AllFields{
+		// Primitive types
 		I:   12,
 		Oi:  &oi,
 		F:   4.2,
@@ -61,10 +73,16 @@ func TestDeepObject(t *testing.T) {
 			ID:   456,
 		},
 		Oo: &oo,
-		D:  d,
-		Od: &d,
 		M:  om,
 		Om: &om,
+
+		// Complex types
+		Bi:  bi,
+		Obi: &bi,
+		Da:  da,
+		Oda: &da,
+		Ti:  ti,
+		Oti: &ti,
 	}
 
 	marshaled, err := MarshalDeepObject(srcObj, "p")

--- a/deepobject_test.go
+++ b/deepobject_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/oapi-codegen/runtime/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -39,6 +40,8 @@ type AllFields struct {
 	Oda *types.Date `json:"oda,omitempty"`
 	Ti  time.Time   `json:"ti"`
 	Oti *time.Time  `json:"oti,omitempty"`
+	U   types.UUID  `json:"u"`
+	Ou  *types.UUID `json:"ou,omitempty"`
 }
 
 func TestDeepObject(t *testing.T) {
@@ -57,6 +60,7 @@ func TestDeepObject(t *testing.T) {
 	bi := MockBinder{Time: time.Date(2020, 2, 1, 0, 0, 0, 0, time.UTC)}
 	da := types.Date{Time: time.Date(2020, 2, 2, 0, 0, 0, 0, time.UTC)}
 	ti := time.Now().UTC()
+	u := uuid.New()
 
 	srcObj := AllFields{
 		// Primitive types
@@ -83,6 +87,8 @@ func TestDeepObject(t *testing.T) {
 		Oda: &da,
 		Ti:  ti,
 		Oti: &ti,
+		U:   u,
+		Ou:  &u,
 	}
 
 	marshaled, err := MarshalDeepObject(srcObj, "p")

--- a/deepobject_test.go
+++ b/deepobject_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/oapi-codegen/nullable"
 	"github.com/oapi-codegen/runtime/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -42,6 +43,13 @@ type AllFields struct {
 	Oti *time.Time  `json:"oti,omitempty"`
 	U   types.UUID  `json:"u"`
 	Ou  *types.UUID `json:"ou,omitempty"`
+
+	// Nullable
+	NiSet   nullable.Nullable[int]         `json:"ni_set,omitempty"`
+	NiNull  nullable.Nullable[int]         `json:"ni_null,omitempty"`
+	NiUnset nullable.Nullable[int]         `json:"ni_unset,omitempty"`
+	No      nullable.Nullable[InnerObject] `json:"no,omitempty"`
+	Nu      nullable.Nullable[uuid.UUID]   `json:"nu,omitempty"`
 }
 
 func TestDeepObject(t *testing.T) {
@@ -89,6 +97,15 @@ func TestDeepObject(t *testing.T) {
 		Oti: &ti,
 		U:   u,
 		Ou:  &u,
+
+		// Nullable
+		NiSet:  nullable.NewNullableWithValue(5),
+		NiNull: nullable.NewNullNullable[int](),
+		No: nullable.NewNullableWithValue(InnerObject{
+			Name: "John Smith",
+			ID:   456,
+		}),
+		Nu: nullable.NewNullableWithValue(uuid.New()),
 	}
 
 	marshaled, err := MarshalDeepObject(srcObj, "p")


### PR DESCRIPTION
Fixes https://github.com/oapi-codegen/runtime/issues/44.

This adjusts deep object unmarshalling to support types that implement `encoding.TextUnmarshaler` (which fixes the issue with with unmarshalling uuid.UUID, and is an interface that is commonly implemented by other types). I'm aware that the `Binder` interface exists however most types from common libraries don't/won't implement it.

It also adjust deep object marshalling to support nil types, marshalling them as `field=null` rather than `field=`.

Finally, it adds custom unmarshalling for the `nullable.Nullable` type. I'm not 100% happy with how I've done this, with the `nullableLike` interface, however because `nullable.Nullable` is generic it's tricky to use casting/reflection to determine the type.