### PR TITLE
fix: make BindQueryParameter play along with x-go-type-skip-optional-pointer

### DIFF
--- a/bindparam.go
+++ b/bindparam.go
@@ -318,7 +318,10 @@ func BindQueryParameter(style string, explode bool, required bool, paramName str
 	// inner code will bind the string's value to this interface.
 	var output interface{}
 
-	if required {
+	// required params are never pointers, but it may happen that optional param
+	// is not pointer as well if user decides to annotate it with
+	// x-go-type-skip-optional-pointer
+	if required || v.Kind() != reflect.Pointer {
 		// If the parameter is required, then the generated code will pass us
 		// a pointer to it: &int, &object, and so forth. We can directly set
 		// them.
@@ -414,9 +417,10 @@ func BindQueryParameter(style string, explode bool, required bool, paramName str
 			if err != nil {
 				return err
 			}
-			// If the parameter is required, and we've successfully unmarshaled
-			// it, this assigns the new object to the pointer pointer.
-			if !required {
+			// If the parameter is required (or relies on x-go-type-skip-optional-pointer),
+			// and we've successfully unmarshaled it, this assigns the new object to the
+			// pointer pointer.
+			if !required && k == reflect.Pointer {
 				dv.Set(reflect.ValueOf(output))
 			}
 			return nil

--- a/bindparam_test.go
+++ b/bindparam_test.go
@@ -339,6 +339,7 @@ func TestBindQueryParameter(t *testing.T) {
 		queryParams := url.Values{
 			"time":   {"2020-12-09T16:09:53+00:00"},
 			"number": {"100"},
+			"text":   {"loremipsum"},
 		}
 		// An optional time will be a pointer to a time in a parameter object
 		var optionalTime *time.Time
@@ -350,6 +351,15 @@ func TestBindQueryParameter(t *testing.T) {
 		err = BindQueryParameter("form", true, false, "notfound", queryParams, &optionalNumber)
 		require.NoError(t, err)
 		assert.Nil(t, optionalNumber)
+
+		var optionalNonPointerText = ""
+		err = BindQueryParameter("form", true, false, "notfound", queryParams, &optionalNonPointerText)
+		require.NoError(t, err)
+		assert.Zero(t, "")
+
+		err = BindQueryParameter("form", true, false, "text", queryParams, &optionalNonPointerText)
+		require.NoError(t, err)
+		assert.Equal(t, "loremipsum", optionalNonPointerText)
 
 		// If we require values, we require errors when they're not present.
 		err = BindQueryParameter("form", true, true, "notfound", queryParams, &optionalTime)


### PR DESCRIPTION
I've run into the same issue as described in https://github.com/oapi-codegen/oapi-codegen/issues/1344 with `in: query` parameters annotated with `x-go-type-skip-optional-pointer` extension. 

I was a bit surprised at the beginning because codegen generates the code with plain struct field (i.e. skips pointer) as expected in the query string params struct but fails with panic during runtime. Turns out it wasn't that hard to fix and it seems am useful addition for users that desire zero values for optional parameters instead of pointers with nil value to communicate lack of parameter. 