### PR TITLE
Fix BindQueryParameter for optional parameters

### DIFF
--- a/bindparam.go
+++ b/bindparam.go
@@ -321,7 +321,8 @@ func BindQueryParameter(style string, explode bool, required bool, paramName str
 	// required params are never pointers, but it may happen that optional param
 	// is not pointer as well if user decides to annotate it with
 	// x-go-type-skip-optional-pointer
-	if required || v.Kind() != reflect.Pointer {
+	var extraIndirect = !required && v.Kind() == reflect.Pointer
+	if !extraIndirect {
 		// If the parameter is required, then the generated code will pass us
 		// a pointer to it: &int, &object, and so forth. We can directly set
 		// them.
@@ -420,7 +421,7 @@ func BindQueryParameter(style string, explode bool, required bool, paramName str
 			// If the parameter is required (or relies on x-go-type-skip-optional-pointer),
 			// and we've successfully unmarshaled it, this assigns the new object to the
 			// pointer pointer.
-			if !required && k == reflect.Pointer {
+			if extraIndirect {
 				dv.Set(reflect.ValueOf(output))
 			}
 			return nil
@@ -460,7 +461,7 @@ func BindQueryParameter(style string, explode bool, required bool, paramName str
 		if err != nil {
 			return err
 		}
-		if !required {
+		if extraIndirect {
 			dv.Set(reflect.ValueOf(output))
 		}
 		return nil

--- a/bindparam_test.go
+++ b/bindparam_test.go
@@ -355,7 +355,7 @@ func TestBindQueryParameter(t *testing.T) {
 		var optionalNonPointerText = ""
 		err = BindQueryParameter("form", true, false, "notfound", queryParams, &optionalNonPointerText)
 		require.NoError(t, err)
-		assert.Zero(t, "")
+		assert.Zero(t, optionalNonPointerText)
 
 		err = BindQueryParameter("form", true, false, "text", queryParams, &optionalNonPointerText)
 		require.NoError(t, err)
@@ -367,6 +367,15 @@ func TestBindQueryParameter(t *testing.T) {
 		err = BindQueryParameter("form", true, true, "notfound", queryParams, &optionalNumber)
 		assert.Error(t, err)
 
+		var optionalPointerText *string
+		err = BindQueryParameter("form", true, false, "notfound", queryParams, &optionalPointerText)
+		require.NoError(t, err)
+		assert.Zero(t, optionalPointerText)
+
+		err = BindQueryParameter("form", true, false, "text", queryParams, &optionalPointerText)
+		require.NoError(t, err)
+		require.NotNil(t, optionalPointerText)
+		assert.Equal(t, "loremipsum", *optionalPointerText)
 	})
 }
 


### PR DESCRIPTION
Hi. Latest commit introduced new error.
I've added test cases, that won't pass on current main branch.
The reason is that k := t.Kind() is String after passing through the else statement.