### PR TITLE
Closes #64 Inorder to fix CVE-2024-44337, github.com/gomarkdown/markdown must be upgraded to version 0.0.0-20240729212818-a2a9c4f76ef5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/go-playground/validator/v10 v10.14.1 // indirect
 	github.com/goccy/go-json v0.10.2 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
-	github.com/gomarkdown/markdown v0.0.0-20230922112808-5421fefb8386 // indirect
+	github.com/gomarkdown/markdown v0.0.0-20250311123330-531bef5e742b // indirect
 	github.com/gorilla/css v1.0.0 // indirect
 	github.com/iris-contrib/schema v0.0.6 // indirect
 	github.com/josharian/intern v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -56,8 +56,8 @@ github.com/goccy/go-json v0.10.2/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MG
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/golang/snappy v0.0.4 h1:yAGX7huGHXlcLOEtBnF4w7FQwA26wojNCwOYAEhLjQM=
 github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
-github.com/gomarkdown/markdown v0.0.0-20230922112808-5421fefb8386 h1:EcQR3gusLHN46TAD+G+EbaaqJArt5vHhNpXAa12PQf4=
-github.com/gomarkdown/markdown v0.0.0-20230922112808-5421fefb8386/go.mod h1:JDGcbDT52eL4fju3sZ4TeHGsQwhG9nbDV21aMyhwPoA=
+github.com/gomarkdown/markdown v0.0.0-20250311123330-531bef5e742b h1:EY/KpStFl60qA17CptGXhwfZ+k1sFNJIUNR8DdbcuUk=
+github.com/gomarkdown/markdown v0.0.0-20250311123330-531bef5e742b/go.mod h1:JDGcbDT52eL4fju3sZ4TeHGsQwhG9nbDV21aMyhwPoA=
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=


### PR DESCRIPTION
Changes in this PR:
- Upgraded the version of github.com/gomarkdown/markdown must be upgraded to version 0.0.0-20240729212818-a2a9c4f76ef5
- Closes the issue: #64 

**Description:**
Vulnerability [[CVE-2024-44337](https://github.com/advisories/GHSA-xhr3-wf7j-h255)] is detected one of the dependency github.com/gomarkdown/markdown. Inorder to fix this vulnerability, github.com/gomarkdown/markdown must be upgraded to version 0.0.0-20240729212818-a2a9c4f76ef5

CVSS Score : 5.1 (Medium)
Severity: Medium
Category "CWE-835 | Loop with Unreachable Exit Condition ('Infinite Loop')
Exploitability: EPSS 3.1% (86th percentile)

Vulnerability score: CVSS: 3

Advisory: https://github.com/advisories/GHSA-xhr3-wf7j-h255
Package: github.com/golang-jwt/jwt/v4
Affected versions< 0.0.0-20240729212818-a2a9c4f76ef5
Patched versions = 0.0.0-20240729212818-a2a9c4f76ef5

CVE Details:
The package github.com/gomarkdown/markdown is a Go library for parsing Markdown text and rendering as HTML. Prior to pseudoversion v0.0.0-20240729232818-a2a9c4f, which corresponds with commit a2a9c4f76ef5a5c32108e36f7c47f8d310322252, there was a logical problem in the paragraph function of the parser/block.go file, which allowed a remote attacker to cause a denial of service (DoS) condition by providing a tailor-made input that caused an infinite loop, causing the program to hang and consume resources indefinitely. Submit a2a9c4f76ef5a5c32108e36f7c47f8d310322252 contains fixes to this problem.

References
https://nvd.nist.gov/vuln/detail/CVE-2024-44337
https://github.com/gomarkdown/markdown/commit/a2a9c4f76ef5a5c32108e36f7c47f8d310322252
https://github.com/Brinmon/CVE-2024-44337
https://pkg.go.dev/vuln/GO-2024-3205