### PR TITLE
Fix: Query param deepObject return without assign on !required

### DIFF
--- a/bindparam.go
+++ b/bindparam.go
@@ -469,7 +469,7 @@ func BindQueryParameter(style string, explode bool, required bool, paramName str
 		if !explode {
 			return errors.New("deepObjects must be exploded")
 		}
-		return UnmarshalDeepObject(dest, paramName, queryParams)
+		return unmarshalDeepObject(dest, paramName, queryParams, required)
 	case "spaceDelimited", "pipeDelimited":
 		return fmt.Errorf("query arguments of style '%s' aren't yet supported", style)
 	default:

--- a/bindparam_test.go
+++ b/bindparam_test.go
@@ -322,6 +322,10 @@ func TestBindQueryParameter(t *testing.T) {
 		err := BindQueryParameter("deepObject", true, false, paramName, queryParams, &actual)
 		assert.NoError(t, err)
 		assert.Equal(t, expectedDeepObject, actual)
+
+		// If we require values, we require errors when they're not present.
+		err = BindQueryParameter("deepObject", true, true, "notfound", queryParams, &actual)
+		assert.Error(t, err)
 	})
 
 	t.Run("form", func(t *testing.T) {

--- a/deepobject.go
+++ b/deepobject.go
@@ -124,6 +124,10 @@ func makeFieldOrValue(paths [][]string, values []string) fieldOrValue {
 }
 
 func UnmarshalDeepObject(dst interface{}, paramName string, params url.Values) error {
+	return unmarshalDeepObject(dst, paramName, params, false)
+}
+
+func unmarshalDeepObject(dst interface{}, paramName string, params url.Values, required bool) error {
 	// Params are all the query args, so we need those that look like
 	// "paramName["...
 	var fieldNames []string
@@ -138,6 +142,14 @@ func UnmarshalDeepObject(dst interface{}, paramName string, params url.Values) e
 				return fmt.Errorf("%s has multiple values", pName)
 			}
 			fieldValues = append(fieldValues, pValues[0])
+		}
+	}
+
+	if len(fieldNames) == 0 {
+		if required {
+			return fmt.Errorf("query parameter '%s' is required", paramName)
+		} else {
+			return nil
 		}
 	}
 


### PR DESCRIPTION
Updated `BindQueryParameter` to return error if query param was not provided but was set as required
Updated `UnmarshalDeepObject` to skip value assign if query param was not provided and not required

Fixes #67 