### PR TITLE
Fix #70: Use %w formatting directives when fmt.Error'ing an error.

### DIFF
--- a/bindparam.go
+++ b/bindparam.go
@@ -83,12 +83,12 @@ func BindStyledParameterWithOptions(style string, paramName string, value string
 		// since prior to this refactoring, they always query unescaped.
 		value, err = url.QueryUnescape(value)
 		if err != nil {
-			return fmt.Errorf("error unescaping query parameter '%s': %v", paramName, err)
+			return fmt.Errorf("error unescaping query parameter '%s': %w", paramName, err)
 		}
 	case ParamLocationPath:
 		value, err = url.PathUnescape(value)
 		if err != nil {
-			return fmt.Errorf("error unescaping path parameter '%s': %v", paramName, err)
+			return fmt.Errorf("error unescaping path parameter '%s': %w", paramName, err)
 		}
 	default:
 		// Headers and cookies aren't escaped.
@@ -97,7 +97,7 @@ func BindStyledParameterWithOptions(style string, paramName string, value string
 	// If the destination implements encoding.TextUnmarshaler we use it for binding
 	if tu, ok := dest.(encoding.TextUnmarshaler); ok {
 		if err := tu.UnmarshalText([]byte(value)); err != nil {
-			return fmt.Errorf("error unmarshaling '%s' text as %T: %s", value, dest, err)
+			return fmt.Errorf("error unmarshaling '%s' text as %T: %w", value, dest, err)
 		}
 
 		return nil
@@ -124,7 +124,7 @@ func BindStyledParameterWithOptions(style string, paramName string, value string
 		// Chop up the parameter into parts based on its style
 		parts, err := splitStyledParameter(style, opts.Explode, false, paramName, value)
 		if err != nil {
-			return fmt.Errorf("error splitting input '%s' into parts: %s", value, err)
+			return fmt.Errorf("error splitting input '%s' into parts: %w", value, err)
 		}
 
 		return bindSplitPartsToDestinationArray(parts, dest)
@@ -287,7 +287,7 @@ func bindSplitPartsToDestinationStruct(paramName string, parts []string, explode
 	jsonParam := "{" + strings.Join(fields, ",") + "}"
 	err := json.Unmarshal([]byte(jsonParam), dest)
 	if err != nil {
-		return fmt.Errorf("error binding parameter %s fields: %s", paramName, err)
+		return fmt.Errorf("error binding parameter %s fields: %w", paramName, err)
 	}
 	return nil
 }

--- a/bindstring.go
+++ b/bindstring.go
@@ -100,7 +100,7 @@ func BindStringToObject(src string, dst interface{}) error {
 	case reflect.Array:
 		if tu, ok := dst.(encoding.TextUnmarshaler); ok {
 			if err := tu.UnmarshalText([]byte(src)); err != nil {
-				return fmt.Errorf("error unmarshaling '%s' text as %T: %s", src, dst, err)
+				return fmt.Errorf("error unmarshaling '%s' text as %T: %w", src, dst, err)
 			}
 
 			return nil
@@ -122,7 +122,7 @@ func BindStringToObject(src string, dst interface{}) error {
 			if err != nil {
 				parsedTime, err = time.Parse(types.DateFormat, src)
 				if err != nil {
-					return fmt.Errorf("error parsing '%s' as RFC3339 or 2006-01-02 time: %s", src, err)
+					return fmt.Errorf("error parsing '%s' as RFC3339 or 2006-01-02 time: %w", src, err)
 				}
 			}
 			// So, assigning this gets a little fun. We have a value to the
@@ -145,7 +145,7 @@ func BindStringToObject(src string, dst interface{}) error {
 			}
 			parsedTime, err := time.Parse(types.DateFormat, src)
 			if err != nil {
-				return fmt.Errorf("error parsing '%s' as date: %s", src, err)
+				return fmt.Errorf("error parsing '%s' as date: %w", src, err)
 			}
 			parsedDate := types.Date{Time: parsedTime}
 

--- a/deepobject.go
+++ b/deepobject.go
@@ -258,7 +258,7 @@ func assignPathValues(dst interface{}, pathValues fieldOrValue) error {
 				// TODO: why is this marked as an ineffassign?
 				tm, err = time.Parse(types.DateFormat, pathValues.value) //nolint:ineffassign,staticcheck
 				if err != nil {
-					return fmt.Errorf("error parsing '%s' as RFC3339 or 2006-01-02 time: %s", pathValues.value, err)
+					return fmt.Errorf("error parsing '%s' as RFC3339 or 2006-01-02 time: %w", pathValues.value, err)
 				}
 				return fmt.Errorf("invalid date format: %w", err)
 			}

--- a/styleparam.go
+++ b/styleparam.go
@@ -80,7 +80,7 @@ func StyleParamWithLocation(style string, explode bool, paramName string, paramL
 		if !convertableToTime && !convertableToDate {
 			b, err := tu.MarshalText()
 			if err != nil {
-				return "", fmt.Errorf("error marshaling '%s' as text: %s", value, err)
+				return "", fmt.Errorf("error marshaling '%s' as text: %w", value, err)
 			}
 
 			return stylePrimitive(style, explode, paramName, paramLocation, string(b))
@@ -166,7 +166,7 @@ func styleSlice(style string, explode bool, paramName string, paramLocation Para
 		part = escapeParameterString(part, paramLocation)
 		parts[i] = part
 		if err != nil {
-			return "", fmt.Errorf("error formatting '%s': %s", paramName, err)
+			return "", fmt.Errorf("error formatting '%s': %w", paramName, err)
 		}
 	}
 	return prefix + strings.Join(parts, separator), nil
@@ -274,7 +274,7 @@ func styleStruct(style string, explode bool, paramName string, paramLocation Par
 		}
 		str, err := primitiveToString(f.Interface())
 		if err != nil {
-			return "", fmt.Errorf("error formatting '%s': %s", paramName, err)
+			return "", fmt.Errorf("error formatting '%s': %w", paramName, err)
 		}
 		fieldDict[fieldName] = str
 	}
@@ -295,7 +295,7 @@ func styleMap(style string, explode bool, paramName string, paramLocation ParamL
 	for _, fieldName := range v.MapKeys() {
 		str, err := primitiveToString(v.MapIndex(fieldName).Interface())
 		if err != nil {
-			return "", fmt.Errorf("error formatting '%s': %s", paramName, err)
+			return "", fmt.Errorf("error formatting '%s': %w", paramName, err)
 		}
 		fieldDict[fieldName.String()] = str
 	}


### PR DESCRIPTION
As explained in #70, not using `%w` formatting directive in some places makes it non-trivial for the user to make use of the error in a meaningful way (`errors.Is` or `errors.As`), outside of string matching. This is particularly painful for errors returned by custom type's `XXXUnmarshaler`  

This PR aims to change the remaining `fmt.Errorf` calls where `%w` directive isn't used but an error is passed while adding no new code.