### PR TITLE
Allow BindStyledParameterWithOptions to fill maps

### DIFF
--- a/bindparam.go
+++ b/bindparam.go
@@ -109,7 +109,7 @@ func BindStyledParameterWithOptions(style string, paramName string, value string
 	// This is the basic type of the destination object.
 	t := v.Type()
 
-	if t.Kind() == reflect.Struct {
+	if t.Kind() == reflect.Struct || t.Kind() == reflect.Map {
 		// We've got a destination object, we'll create a JSON representation
 		// of the input value, and let the json library deal with the unmarshaling
 		parts, err := splitStyledParameter(style, opts.Explode, true, paramName, value)

--- a/bindparam_test.go
+++ b/bindparam_test.go
@@ -509,15 +509,52 @@ func TestBindParamsToExplodedObject(t *testing.T) {
 }
 
 func TestBindStyledParameterWithLocation(t *testing.T) {
-	expectedBig := big.NewInt(12345678910)
+	t.Run("bigNumber", func(t *testing.T) {
+		expectedBig := big.NewInt(12345678910)
+		var dstBigNumber big.Int
 
-	var dstBigNumber big.Int
-
-	err := BindStyledParameterWithOptions("simple", "id", "12345678910", &dstBigNumber, BindStyledParameterOptions{
-		ParamLocation: ParamLocationUndefined,
-		Explode:       false,
-		Required:      false,
+		err := BindStyledParameterWithOptions("simple", "id", "12345678910", &dstBigNumber, BindStyledParameterOptions{
+			ParamLocation: ParamLocationUndefined,
+			Explode:       false,
+			Required:      false,
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, *expectedBig, dstBigNumber)
 	})
-	assert.NoError(t, err)
-	assert.Equal(t, *expectedBig, dstBigNumber)
+
+	t.Run("object", func(t *testing.T) {
+		type Object struct {
+			Key1 string `json:"key1"`
+			Key2 string `json:"key2"`
+		}
+		expectedObject := Object{
+			Key1: "value1",
+			Key2: "42",
+		}
+		var dstObject Object
+
+		err := BindStyledParameterWithOptions("simple", "map", "key1,value1,key2,42", &dstObject, BindStyledParameterOptions{
+			ParamLocation: ParamLocationUndefined,
+			Explode:       false,
+			Required:      false,
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, *&expectedObject, dstObject)
+	})
+
+	t.Run("map", func(t *testing.T) {
+		expectedMap := map[string]any{
+			"key1": "value1",
+			"key2": "42",
+		}
+		var dstMap map[string]any
+
+		err := BindStyledParameterWithOptions("simple", "map", "key1,value1,key2,42", &dstMap, BindStyledParameterOptions{
+			ParamLocation: ParamLocationUndefined,
+			Explode:       false,
+			Required:      false,
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, *&expectedMap, dstMap)
+	})
 }


### PR DESCRIPTION
In our API we have something like:

```yaml
  /v2/store/{key}:
    put:
      summary: Store with Metadata
      parameters:
        - name: key
          in: path
          required: true
          explode: false
          style: simple
          schema:
            type: string
        - name: X-Metadata
          in: header
          required: false
          explode: false
          schema:
            type: object
            additionalProperties:
              type: string
```
If the X-Metadata header is defined with e.g. "foo,bar" I always get the error:`Invalid format for parameter X-Metadata: error binding string parameter: can not bind to destination of type: map`.

The issue is that the X-Metadata type is a map[string]string which is not handled by `BindStyledParameterWithOptions`.

I extended the function to use the same code path for reflect.Map as for reflect.Struct