### PR TITLE
fix: correct time.Time date-only fallback parsing in deepObject

### DIFF
--- a/deepobject.go
+++ b/deepobject.go
@@ -258,11 +258,10 @@ func assignPathValues(dst interface{}, pathValues fieldOrValue) error {
 			tm, err = time.Parse(time.RFC3339Nano, pathValues.value)
 			if err != nil {
 				// Fall back to parsing it as a date.
-				_, err = time.Parse(types.DateFormat, pathValues.value) // the time result is never used, so it doesn't need to be assigned
+				tm, err = time.Parse(types.DateFormat, pathValues.value)
 				if err != nil {
 					return fmt.Errorf("error parsing '%s' as RFC3339 or 2006-01-02 time: %w", pathValues.value, err)
 				}
-				return fmt.Errorf("invalid date format: %w", err)
 			}
 			dst := iv
 			if it != reflect.TypeOf(time.Time{}) {

--- a/deepobject_test.go
+++ b/deepobject_test.go
@@ -123,6 +123,42 @@ type Item struct {
 	Value string `json:"value"`
 }
 
+func TestDeepObject_TimeFields(t *testing.T) {
+	type TimeObject struct {
+		Created time.Time `json:"created"`
+	}
+
+	t.Run("RFC3339 time parses correctly", func(t *testing.T) {
+		params := url.Values{}
+		params.Set("p[created]", "2024-01-15T10:30:00Z")
+
+		var dst TimeObject
+		err := UnmarshalDeepObject(&dst, "p", params)
+		require.NoError(t, err)
+		assert.Equal(t, time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC), dst.Created)
+	})
+
+	t.Run("date-only string parses correctly as time.Time", func(t *testing.T) {
+		params := url.Values{}
+		params.Set("p[created]", "2024-01-15")
+
+		var dst TimeObject
+		err := UnmarshalDeepObject(&dst, "p", params)
+		require.NoError(t, err)
+		assert.Equal(t, time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC), dst.Created)
+	})
+
+	t.Run("invalid time string returns error", func(t *testing.T) {
+		params := url.Values{}
+		params.Set("p[created]", "not-a-time")
+
+		var dst TimeObject
+		err := UnmarshalDeepObject(&dst, "p", params)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "error parsing")
+	})
+}
+
 func TestDeepObject_ArrayOfObjects(t *testing.T) {
 	// Test case for:
 	// name: items


### PR DESCRIPTION
The date-only fallback in assignPathValues erroneously returned an error wrapping nil after a successful parse, preventing date-only strings from being unmarshalled into time.Time fields via deepObject.