### PR TITLE
fix: add TypeHint-aware parameter binding and styling for []byte (#97)

### DIFF
--- a/paramformat.go
+++ b/paramformat.go
@@ -1,0 +1,52 @@
+package runtime
+
+import (
+	"encoding/base64"
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+// isByteSlice reports whether t is []byte (or equivalently []uint8).
+func isByteSlice(t reflect.Type) bool {
+	return t.Kind() == reflect.Slice && t.Elem().Kind() == reflect.Uint8
+}
+
+// base64Decode decodes s as base64.
+//
+// Per OpenAPI 3.0, format: byte uses RFC 4648 Section 4 (standard alphabet,
+// padded). We use padding presence to select the right decoder, rather than
+// blindly cascading (which can produce corrupt output when RawStdEncoding
+// silently accepts padded input and treats '=' as data).
+//
+// The logic:
+//  1. If s contains '=' padding → standard padded decoder (Std or URL based on alphabet).
+//  2. If s contains URL-safe characters ('_' or '-') → RawURLEncoding.
+//  3. Otherwise → RawStdEncoding (unpadded, standard alphabet).
+func base64Decode(s string) ([]byte, error) {
+	if s == "" {
+		return []byte{}, nil
+	}
+
+	if strings.ContainsRune(s, '=') {
+		// Padded input. Pick alphabet based on whether URL-safe chars are present.
+		if strings.ContainsAny(s, "-_") {
+			return base64Decode1(base64.URLEncoding, s)
+		}
+		return base64Decode1(base64.StdEncoding, s)
+	}
+
+	// Unpadded input. Pick alphabet based on whether URL-safe chars are present.
+	if strings.ContainsAny(s, "-_") {
+		return base64Decode1(base64.RawURLEncoding, s)
+	}
+	return base64Decode1(base64.RawStdEncoding, s)
+}
+
+func base64Decode1(enc *base64.Encoding, s string) ([]byte, error) {
+	b, err := enc.DecodeString(s)
+	if err != nil {
+		return nil, fmt.Errorf("failed to base64-decode string %q: %w", s, err)
+	}
+	return b, nil
+}

--- a/paramformat_test.go
+++ b/paramformat_test.go
@@ -1,0 +1,80 @@
+package runtime
+
+import (
+	"encoding/base64"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsByteSlice(t *testing.T) {
+	assert.True(t, isByteSlice(reflect.TypeOf([]byte{})))
+	assert.True(t, isByteSlice(reflect.TypeOf([]uint8{})))
+
+	assert.False(t, isByteSlice(reflect.TypeOf([]int{})))
+	assert.False(t, isByteSlice(reflect.TypeOf([]string{})))
+	assert.False(t, isByteSlice(reflect.TypeOf("")))
+	assert.False(t, isByteSlice(reflect.TypeOf(0)))
+
+	// Type alias for []byte should also be detected
+	type MyBytes []byte
+	assert.True(t, isByteSlice(reflect.TypeOf(MyBytes{})))
+}
+
+func TestBase64Decode(t *testing.T) {
+	t.Run("standard encoding with padding", func(t *testing.T) {
+		// "test" → StdEncoding → "dGVzdA=="
+		b, err := base64Decode("dGVzdA==")
+		require.NoError(t, err)
+		assert.Equal(t, []byte("test"), b)
+	})
+
+	t.Run("standard encoding without padding", func(t *testing.T) {
+		// "test" → RawStdEncoding → "dGVzdA"
+		b, err := base64Decode("dGVzdA")
+		require.NoError(t, err)
+		assert.Equal(t, []byte("test"), b)
+	})
+
+	t.Run("URL-safe encoding without padding", func(t *testing.T) {
+		// Contains '_' and '-' → dispatches to RawURLEncoding
+		input := "PDw_Pz4-"
+		b, err := base64Decode(input)
+		require.NoError(t, err)
+		expected, decErr := base64.RawURLEncoding.DecodeString(input)
+		require.NoError(t, decErr)
+		assert.Equal(t, expected, b)
+	})
+
+	t.Run("URL-safe encoding with padding", func(t *testing.T) {
+		// Contains '_' and '=' → dispatches to URLEncoding (padded)
+		input := base64.URLEncoding.EncodeToString([]byte("<<??>>"))
+		b, err := base64Decode(input)
+		require.NoError(t, err)
+		assert.Equal(t, []byte("<<??>>"), b)
+	})
+
+	t.Run("empty string", func(t *testing.T) {
+		b, err := base64Decode("")
+		require.NoError(t, err)
+		assert.Equal(t, []byte{}, b)
+	})
+
+	t.Run("invalid base64", func(t *testing.T) {
+		_, err := base64Decode("!!!not-base64!!!")
+		assert.Error(t, err)
+	})
+
+	t.Run("padded input not corrupted by wrong decoder", func(t *testing.T) {
+		// This is the key correctness test. With the old blind cascade,
+		// RawStdEncoding would "succeed" on padded input but produce
+		// garbage bytes (treating '=' as data). The new logic dispatches
+		// padded input to StdEncoding directly.
+		input := base64.StdEncoding.EncodeToString([]byte("hello world"))
+		b, err := base64Decode(input)
+		require.NoError(t, err)
+		assert.Equal(t, []byte("hello world"), b)
+	})
+}


### PR DESCRIPTION
When an OpenAPI spec uses type: string, format: byte, oapi-codegen generates a []byte field. Previously the runtime treated []byte as a generic []uint8 slice -- splitting on commas and parsing individual integers -- instead of base64 encoding/decoding.

This adds a TypeHint mechanism via new WithOptions variants of existing functions. Existing functions delegate to the new variants with zero-value options, preserving all current behavior. Only when TypeHintBinary is explicitly passed does base64 handling activate.

Encoding uses base64.StdEncoding (standard alphabet, padded) per OpenAPI 3.0 reference to RFC 4648 Section 4.

Decoding is lenient: it inspects the input to select the correct decoder rather than blindly cascading (which could corrupt data when RawStdEncoding silently accepts padded input and treats '=' as data). If '=' padding is present, it uses the padded decoder; otherwise the raw (unpadded) decoder. If URL-safe characters ('-' or '_') are present, it uses the URL-safe alphabet; otherwise the standard alphabet. This accommodates real-world clients that may send unpadded or URL-safe base64, while still being correct for spec-compliant padded standard base64.

New public API:
  - TypeHint, TypeHintNone, TypeHintBinary
  - BindStringToObjectOptions / BindStringToObjectWithOptions
  - StyleParamOptions / StyleParamWithOptions
  - BindQueryParameterOptions / BindQueryParameterWithOptions
  - BindStyledParameterOptions.TypeHint field

The oapi-codegen code generator must be updated separately to emit calls to these new WithOptions functions with TypeHintBinary for format: byte fields. Until then, generated code continues to use the existing functions with unchanged behavior.