### PR TITLE
Add missing required parameter detection

### DIFF
--- a/bindparam.go
+++ b/bindparam.go
@@ -475,8 +475,14 @@ func BindQueryParameterWithOptions(style string, explode bool, required bool, pa
 				var fieldsPresent bool
 				fieldsPresent, err = bindParamsToExplodedObject(paramName, queryParams, output)
 				// If no fields were set, and there is no error, we will not fall
-				// through to assign the destination.
+				// through to assign the destination. An absent required
+				// parameter is an error, matching the slice and primitive cases
+				// above; this also covers scalar struct types such as
+				// types.Date and time.Time.
 				if !fieldsPresent {
+					if required {
+						return &RequiredParameterError{ParamName: paramName}
+					}
 					return nil
 				}
 			default:
@@ -707,7 +713,13 @@ func BindRawQueryParameter(style string, explode bool, required bool, paramName 
 			case reflect.Struct:
 				var fieldsPresent bool
 				fieldsPresent, err = bindParamsToExplodedObject(paramName, queryParams, output)
+				// An absent required parameter is an error, matching the slice
+				// and primitive cases above; this also covers scalar struct
+				// types such as types.Date and time.Time.
 				if !fieldsPresent {
+					if required {
+						return &RequiredParameterError{ParamName: paramName}
+					}
 					return nil
 				}
 			default:

--- a/bindparam_test.go
+++ b/bindparam_test.go
@@ -544,6 +544,26 @@ func TestBindQueryParameter(t *testing.T) {
 		assert.Nil(t, date)
 	})
 
+	// Regression test for https://github.com/oapi-codegen/runtime/issues/134:
+	// an absent *required* date (a struct-typed param) must report a
+	// RequiredParameterError, not pass silently. The exploded form path
+	// previously returned nil here, dropping the required check.
+	t.Run("date_form_explode_required_missing", func(t *testing.T) {
+		var date types.Date
+		queryParams := url.Values{}
+		err := BindQueryParameter("form", true, true, "date", queryParams, &date)
+		var requiredErr *RequiredParameterError
+		assert.ErrorAs(t, err, &requiredErr)
+	})
+
+	t.Run("date_form_no_explode_required_missing", func(t *testing.T) {
+		var date types.Date
+		queryParams := url.Values{}
+		err := BindQueryParameter("form", false, true, "date", queryParams, &date)
+		var requiredErr *RequiredParameterError
+		assert.ErrorAs(t, err, &requiredErr)
+	})
+
 	t.Run("date_form_no_explode_required", func(t *testing.T) {
 		expectedDate := types.Date{Time: time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)}
 		var date types.Date


### PR DESCRIPTION
Closes: #134

The exploded form path bound struct-typed query params (e.g. types.Date, time.Time) via bindParamsToExplodedObject and returned nil when no fields were present, dropping the required check that the slice and primitive cases already perform. A missing required date param therefore passed silently instead of returning a RequiredParameterError.

Honor required in the reflect.Struct case of both
BindQueryParameterWithOptions and BindRawQueryParameter, and add regression tests for the absent-required case.