### PR TITLE
Support binding deepObject parameters into map[string]interface{}

### DIFF
--- a/deepobject.go
+++ b/deepobject.go
@@ -360,6 +360,24 @@ func assignPathValues(dst interface{}, pathValues fieldOrValue) error {
 		err := assignPathValues(dstPtr, pathValues)
 		iv.Set(dstVal)
 		return err
+	case reflect.Interface:
+		// An empty interface carries no type information to bind against —
+		// this is the element type of the map[string]interface{} generated
+		// for `additionalProperties: true` (issue #138). Synthesize the
+		// generic value shapes encoding/json uses from the shape of the
+		// parsed fragment instead.
+		if it.NumMethod() != 0 {
+			// A non-empty interface can't be satisfied by a synthesized
+			// value; report it like any other unbindable destination.
+			return errors.New("unhandled type: " + it.String())
+		}
+		val := interfaceFromFieldOrValue(pathValues)
+		if val == nil {
+			iv.Set(reflect.Zero(it))
+		} else {
+			iv.Set(reflect.ValueOf(val))
+		}
+		return nil
 	case reflect.Bool:
 		val, err := strconv.ParseBool(pathValues.value)
 		if err != nil {
@@ -394,6 +412,68 @@ func assignPathValues(dst interface{}, pathValues fieldOrValue) error {
 	default:
 		return errors.New("unhandled type: " + it.String())
 	}
+}
+
+// interfaceFromFieldOrValue converts a parsed deepObject fragment into the
+// generic value shapes encoding/json produces: map[string]interface{} for
+// objects, []interface{} for arrays (consecutive integer subscripts, the
+// shape MarshalDeepObject emits), and JSON scalars for leaf values. This
+// round-trips a map[string]interface{} through MarshalDeepObject and back,
+// up to the inherent ambiguities of the untyped wire format: a string that
+// spells a JSON scalar ("true", "12.5") comes back as that scalar, and a
+// map whose keys are exactly "0".."n-1" comes back as an array.
+func interfaceFromFieldOrValue(fv fieldOrValue) interface{} {
+	if len(fv.fields) == 0 {
+		return jsonScalarFromString(fv.value)
+	}
+	if keys, ok := consecutiveIndices(fv.fields); ok {
+		arr := make([]interface{}, len(keys))
+		for i, key := range keys {
+			arr[i] = interfaceFromFieldOrValue(fv.fields[key])
+		}
+		return arr
+	}
+	m := make(map[string]interface{}, len(fv.fields))
+	for key, value := range fv.fields {
+		m[key] = interfaceFromFieldOrValue(value)
+	}
+	return m
+}
+
+// jsonScalarFromString maps raw query text to the value encoding/json would
+// produce for the same literal: true/false, null, or a number (float64).
+// Text that is not a JSON scalar stays a string — notably "00714", which the
+// JSON number grammar rejects (leading zero), so zip-code-like values keep
+// their exact form.
+func jsonScalarFromString(s string) interface{} {
+	switch s {
+	case "true":
+		return true
+	case "false":
+		return false
+	case "null":
+		return nil
+	}
+	var n float64
+	if err := json.Unmarshal([]byte(s), &n); err == nil {
+		return n
+	}
+	return s
+}
+
+// consecutiveIndices reports whether the field keys are exactly the integer
+// subscripts "0".."n-1" — the shape MarshalDeepObject emits for arrays —
+// and returns the keys in index order.
+func consecutiveIndices(fields map[string]fieldOrValue) ([]string, bool) {
+	keys := make([]string, len(fields))
+	for k := range fields {
+		i, err := strconv.Atoi(k)
+		if err != nil || i < 0 || i >= len(fields) || keys[i] != "" {
+			return nil, false
+		}
+		keys[i] = k
+	}
+	return keys, true
 }
 
 func assignSlice(dst reflect.Value, pathValues fieldOrValue) error {

--- a/deepobject_test.go
+++ b/deepobject_test.go
@@ -443,3 +443,75 @@ func TestDeepObject_URLEncoding(t *testing.T) {
 			"expected UTF-8 percent-encoded value; got %q", marshaled)
 	})
 }
+
+// TestDeepObject_InterfaceDestination covers binding into
+// map[string]interface{}, the type generated for a deepObject parameter
+// declared with `additionalProperties: true`. There is no type information
+// to bind against, so leaves are typed by JSON-scalar inference and
+// consecutive integer subscripts become []interface{}.
+// See https://github.com/oapi-codegen/runtime/issues/138 and
+// https://github.com/oapi-codegen/oapi-codegen/issues/2177
+func TestDeepObject_InterfaceDestination(t *testing.T) {
+	params, err := url.ParseQuery(strings.Join([]string{
+		"properties[vaccinated]=true",
+		"properties[color]=black",
+		"properties[coat_length]=large",
+		"properties[weight]=12.5",
+		"properties[zip]=00714",
+		"properties[chipped]=null",
+		"properties[owner][name]=alice",
+		"properties[owner][phones][0]=555-0100",
+		"properties[owner][phones][1]=555-0101",
+		"properties[scores][0]=1",
+		"properties[scores][2]=3",
+	}, "&"))
+	require.NoError(t, err)
+
+	want := map[string]interface{}{
+		"vaccinated":  true,
+		"color":       "black",
+		"coat_length": "large",
+		"weight":      12.5,
+		// Not a valid JSON number (leading zero), so it stays a string.
+		"zip":     "00714",
+		"chipped": nil,
+		"owner": map[string]interface{}{
+			"name":   "alice",
+			"phones": []interface{}{"555-0100", "555-0101"},
+		},
+		// Non-consecutive subscripts are not an array; they stay a map.
+		"scores": map[string]interface{}{"0": 1.0, "2": 3.0},
+	}
+
+	var dst map[string]interface{}
+	require.NoError(t, UnmarshalDeepObject(&dst, "properties", params))
+	assert.Equal(t, want, dst)
+
+	// The generated params struct field for an optional parameter is a
+	// pointer; make sure that path allocates and binds too.
+	var pdst *map[string]interface{}
+	require.NoError(t, UnmarshalDeepObject(&pdst, "properties", params))
+	require.NotNil(t, pdst)
+	assert.Equal(t, want, *pdst)
+}
+
+// TestDeepObject_InterfaceRoundTrip verifies that a map[string]interface{}
+// serialized by MarshalDeepObject binds back to an equal value.
+func TestDeepObject_InterfaceRoundTrip(t *testing.T) {
+	src := map[string]interface{}{
+		"vaccinated": true,
+		"color":      "black",
+		"weight":     12.5,
+		"chipped":    nil,
+		"owner": map[string]interface{}{
+			"name":   "alice",
+			"phones": []interface{}{"555-0100", "555-0101"},
+		},
+	}
+
+	marshaled, err := MarshalDeepObject(src, "properties")
+	require.NoError(t, err)
+
+	var dst map[string]interface{}
+	assertDeepObjectWireSafe(t, marshaled, "properties", &dst, src)
+}


### PR DESCRIPTION
Closes: #138

Binding a deepObject query parameter into map[string]interface{} — the type generated for a schema with `additionalProperties: true` — failed with "unhandled type: interface {}" because assignPathValues had no case for interface destinations.

An empty interface destination now receives the generic value shapes encoding/json uses, synthesized from the shape of the parsed fragment: leaves are typed by JSON-scalar inference ("true" -> bool, "12.5" -> float64, "null" -> nil, anything else stays a string — the JSON number grammar rejects leading zeros, so values like "00714" keep their exact form), consecutive integer subscripts "0".."n-1" become []interface{}, and other nodes become map[string]interface{}, recursively. Non-empty interface destinations still report an unhandled type.

This also makes MarshalDeepObject output for a map[string]interface{} round-trip through binding, up to the inherent ambiguities of the untyped wire format, which are documented on the new helpers.