### PR TITLE
Prefer the form struct tag over json for form encoding

### DIFF
--- a/bindform.go
+++ b/bindform.go
@@ -13,8 +13,22 @@ import (
 	"github.com/oapi-codegen/runtime/types"
 )
 
-const tagName = "json"
+const jsonTagName = "json"
+const formTagName = "form"
 const jsonContentType = "application/json"
+
+// formFieldTag returns the struct tag value that names a field on the wire
+// for form encoding. The `form` tag is preferred when present and non-empty;
+// the `json` tag is the historical fallback, kept for compatibility with
+// generated and hand-written structs that carry only json tags. The full tag
+// value is returned, so `-` skips and the `,omitempty` option follow
+// whichever tag was selected.
+func formFieldTag(f reflect.StructField) string {
+	if tag, ok := f.Tag.Lookup(formTagName); ok && tag != "" {
+		return tag
+	}
+	return f.Tag.Get(jsonTagName)
+}
 
 type RequestBodyEncoding struct {
 	ContentType string
@@ -41,7 +55,7 @@ func BindForm(ptr interface{}, form map[string][]string, files map[string][]*mul
 
 	for i := 0; i < tValue.NumField(); i++ {
 		field := ptrVal.Field(i)
-		tag := tValue.Field(i).Tag.Get(tagName)
+		tag := formFieldTag(tValue.Field(i))
 		if !field.CanInterface() || tag == "-" {
 			continue
 		}
@@ -97,7 +111,7 @@ func MarshalForm(ptr interface{}, encodings map[string]RequestBodyEncoding) (url
 	result := make(url.Values)
 	for i := 0; i < tValue.NumField(); i++ {
 		field := ptrVal.Field(i)
-		tag := tValue.Field(i).Tag.Get(tagName)
+		tag := formFieldTag(tValue.Field(i))
 		if !field.CanInterface() || tag == "-" {
 			continue
 		}
@@ -175,7 +189,7 @@ func bindFormImpl(v reflect.Value, form map[string][]string, files map[string][]
 		}
 		for i := 0; i < v.NumField(); i++ {
 			field := v.Type().Field(i)
-			tag := field.Tag.Get(tagName)
+			tag := formFieldTag(field)
 			if field.Name == "AdditionalProperties" && field.Type.Kind() == reflect.Map && tag == "-" {
 				additionalPropertiesHasData, err := bindAdditionalProperties(v.Field(i), v, form, files, name)
 				if err != nil {
@@ -258,7 +272,7 @@ func bindAdditionalProperties(additionalProperties reflect.Value, parentStruct r
 	// store all fixed properties in a set
 	fieldsSet := make(map[string]struct{})
 	for i := 0; i < parentStruct.NumField(); i++ {
-		tag := parentStruct.Type().Field(i).Tag.Get(tagName)
+		tag := formFieldTag(parentStruct.Type().Field(i))
 		if !parentStruct.Field(i).CanInterface() || tag == "-" {
 			continue
 		}
@@ -383,7 +397,7 @@ func marshalFormImpl(v reflect.Value, result url.Values, name string) {
 	case reflect.Struct:
 		for i := 0; i < v.NumField(); i++ {
 			field := v.Type().Field(i)
-			tag := field.Tag.Get(tagName)
+			tag := formFieldTag(field)
 			if field.Name == "AdditionalProperties" && tag == "-" {
 				iter := v.MapRange()
 				for iter.Next() {

--- a/bindform_test.go
+++ b/bindform_test.go
@@ -275,3 +275,50 @@ func makeMultipartFilesForm(files []fileData) (*multipart.Form, error) {
 	mr := multipart.NewReader(&buffer, mw.Boundary())
 	return mr.ReadForm(1024)
 }
+
+// TestFormTagPreferredOverJSONTag covers issue #128: form encoding keys on
+// the `form` struct tag when present — for field names, `-` skips and
+// `,omitempty` — falling back to the `json` tag for structs that only carry
+// json tags.
+func TestFormTagPreferredOverJSONTag(t *testing.T) {
+	type testSubStruct struct {
+		Value string `json:"json_value" form:"form_value"`
+	}
+	type testStruct struct {
+		// Divergent names: the form name must win on the wire.
+		Renamed string `json:"json_name" form:"form_name"`
+		// omitempty only on the form tag: zero value is omitted even
+		// though the json tag would keep it.
+		FormOmit string `json:"keep" form:"form_omit,omitempty"`
+		// omitempty only on the json tag: the form tag wins, so the zero
+		// value is NOT omitted.
+		JSONOmit string `json:"json_omit,omitempty" form:"form_keep"`
+		// Skipped for form encoding only.
+		FormSkipped string `json:"json_visible" form:"-"`
+		// No form tag: json tag remains authoritative.
+		Fallback string `json:"fallback_name,omitempty"`
+		// Nested structs resolve their fields the same way.
+		Nested testSubStruct `form:"nested,omitempty"`
+	}
+
+	src := testStruct{
+		Renamed:     "a",
+		FormSkipped: "hidden",
+		Fallback:    "b",
+		Nested:      testSubStruct{Value: "c"},
+	}
+
+	marshaled, err := MarshalForm(src, nil)
+	require.NoError(t, err)
+	encoded, err := url.QueryUnescape(marshaled.Encode())
+	require.NoError(t, err)
+	assert.Equal(t, "fallback_name=b&form_keep=&form_name=a&nested[form_value]=c", encoded)
+
+	// Binding uses the same tag resolution, so the marshaled form
+	// round-trips (minus the form-skipped field).
+	var dst testStruct
+	require.NoError(t, BindForm(&dst, marshaled, nil, nil))
+	want := src
+	want.FormSkipped = ""
+	assert.Equal(t, want, dst)
+}


### PR DESCRIPTION
Closes: #128

MarshalForm decided field names, "-" skips and omitempty from the json struct tag, and BindForm and the nested form marshal/bind helpers did the same, so a form tag on a field was ignored entirely — including the omitempty case reported in the issue.

Tag resolution for form encoding now goes through formFieldTag, which prefers the form tag when present and non-empty and falls back to the json tag. The fallback keeps structs that only carry json tags — older generated code, multipart bodies, hand-written types — behaving exactly as before, while structs with a form tag get it honored consistently across BindForm, MarshalForm and the nested helpers, so form data round-trips under one set of names.