### PR TITLE
Explain how to send nested objects when style serialization fails

### DIFF
--- a/styleparam.go
+++ b/styleparam.go
@@ -491,6 +491,15 @@ func primitiveToString(value interface{}) (string, error) {
 	default:
 		v, ok := value.(fmt.Stringer)
 		if !ok {
+			if kind == reflect.Struct || kind == reflect.Map {
+				// A nested object inside a styled parameter: OpenAPI
+				// style-based serialization is only defined for primitives,
+				// arrays and flat objects, so there is no wire format we
+				// could produce here.
+				return "", fmt.Errorf(
+					"cannot serialize nested object of type %s: style-based parameter serialization ('style'/'schema') is only defined for primitives, arrays, and flat objects; declare the parameter with 'content: application/json' instead, or map the schema to a Go type implementing fmt.Stringer",
+					reflect.TypeOf(value).String())
+			}
 			return "", fmt.Errorf("unsupported type %s", reflect.TypeOf(value).String())
 		}
 

--- a/styleparam_test.go
+++ b/styleparam_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/oapi-codegen/runtime/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestStyleParam(t *testing.T) {
@@ -893,4 +894,23 @@ func TestStyleParamNameEncoding(t *testing.T) {
 		assert.NoError(t, err)
 		assert.EqualValues(t, "filter%5B%5D[name]=foo", result)
 	})
+}
+
+// TestStyleParamNestedStructError covers issue #52: OpenAPI style-based
+// serialization has no defined wire format for nested objects, so styling a
+// struct containing another struct must fail with an error that points at
+// the 'content: application/json' parameter form instead of a bare
+// "unsupported type".
+func TestStyleParamNestedStructError(t *testing.T) {
+	type Header struct {
+		Name string `json:"name"`
+	}
+	type ParentStruct struct {
+		Header Header `json:"header"`
+	}
+
+	_, err := StyleParamWithLocation("form", true, "param_id", ParamLocationQuery, ParentStruct{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot serialize nested object of type runtime.Header")
+	assert.Contains(t, err.Error(), "content: application/json")
 }


### PR DESCRIPTION
Refs: #52

Styling a parameter whose object schema contains a nested object failed with a bare "unsupported type Header", which gives no hint that the spec itself defines no wire format for this. OpenAPI style-based serialization covers only primitives, arrays, and flat objects; complex values are meant to use the parameter's content form (e.g. `content: application/json`).

When a struct or map reaches primitiveToString without satisfying any of the serialization escape hatches, the error now says exactly that and points at declaring the parameter with `content: application/json` (or mapping the schema to a Go type implementing fmt.Stringer). Behavior is otherwise unchanged: nested objects still fail to serialize, by design.