### PR TITLE
chore: use go mod tidy instead of tidied

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,6 @@ tidy:
 
 tidy-ci:
 	# for the root module, explicitly run the step, to prevent recursive calls
-	tidied -verbose
+	go mod tidy -diff
 	# then, for all child modules, use a module-managed `Makefile`
 	git ls-files '**/*go.mod' -z | xargs -0 -I{} bash -xc 'cd $$(dirname {}) && make tidy-ci'

--- a/strictmiddleware/echo-v5/Makefile
+++ b/strictmiddleware/echo-v5/Makefile
@@ -20,7 +20,7 @@ tidy:
 	go mod tidy
 
 tidy-ci:
-	tidied -verbose
+	go mod tidy -diff
 
 else
 


### PR DESCRIPTION
The same as https://github.com/oapi-codegen/oapi-codegen/pull/2482